### PR TITLE
Use subdomains instead of path prefix

### DIFF
--- a/recipes/filebrowser/metadata.yaml
+++ b/recipes/filebrowser/metadata.yaml
@@ -7,10 +7,10 @@ architecture:
   - armhf
   - arm64
 url: https://filebrowser.org/
-recipeVersion: "1.0.2"
+recipeVersion: "1.1.0"
 appVersion: latest
 maintainers:
-  - volker.theile@openmediavault.org
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://filebrowser.org/
   - https://utkuozdemir.org/helm-charts/

--- a/recipes/filebrowser/recipe.yaml
+++ b/recipes/filebrowser/recipe.yaml
@@ -1,4 +1,4 @@
-# The app can be reached at https://<FQDN>:8443/filebrowser
+# The app can be reached at https://filebrowser.<FQDN>:8443
 ---
 apiVersion: v1
 kind: Namespace
@@ -10,6 +10,9 @@ kind: HelmChart
 metadata:
   name: filebrowser
   namespace: filebrowser-app
+  labels:
+    app.kubernetes.io/instance: filebrowser
+    app.kubernetes.io/name: filebrowser
 spec:
   repo: https://utkuozdemir.org/helm-charts
   chart: filebrowser
@@ -30,18 +33,21 @@ spec:
         # with has access to that directory.
         path: {{ sharedfolder_path('<NAME>') }} # <<< Replace
     config:
-      baseURL: /filebrowser
+      baseURL: /
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: filebrowser-websecure
   namespace: filebrowser-app
+  labels:
+    app.kubernetes.io/instance: filebrowser
+    app.kubernetes.io/name: filebrowser
 spec:
   entryPoints:
     - websecure
   routes:
-    - match: PathPrefix(`/filebrowser`)
+    - match: Host(`filebrowser.{{ fqdn() }}`)
       kind: Rule
       services:
         - name: filebrowser

--- a/recipes/jellyfin/metadata.yaml
+++ b/recipes/jellyfin/metadata.yaml
@@ -6,10 +6,10 @@ architecture:
   - armhf
   - arm64
 url: https://jellyfin.org/
-recipeVersion: "1.0"
+recipeVersion: "1.1.0"
 appVersion: latest
 maintainers:
-  - volker.theile@openmediavault.org
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://github.com/jellyfin/jellyfin
   - https://hub.docker.com/r/jellyfin/jellyfin

--- a/recipes/jellyfin/recipe.yaml
+++ b/recipes/jellyfin/recipe.yaml
@@ -1,4 +1,4 @@
-# The app can be reached at http://<FQDN>:30096
+# The app can be reached at https://jellyfin.<FQDN>:8443
 ---
 apiVersion: v1
 kind: Namespace
@@ -82,13 +82,28 @@ metadata:
     app.kubernetes.io/instance: jellyfin
     app.kubernetes.io/name: jellyfin
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
-    - name: http
-      port: 8096
-      nodePort: 30096
+    - port: 8096
       protocol: TCP
       targetPort: 8096
   selector:
     app.kubernetes.io/instance: jellyfin
     app.kubernetes.io/name: jellyfin
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: jellyfin-websecure
+  namespace: jellyfin-app
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`jellyfin.{{ fqdn() }}`)
+      kind: Rule
+      services:
+        - name: jellyfin
+          port: 8096
+  tls:
+    secretName: host-selfsigned-cert # <<< Use 'host-imported-cert' if you want to use the SSL cert specified in the settings.

--- a/recipes/minio/metadata.yaml
+++ b/recipes/minio/metadata.yaml
@@ -8,7 +8,7 @@ url: https://min.io/
 recipeVersion: "1.0.0"
 appVersion: latest
 maintainers:
-  - volker.theile@openmediavault.org
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://min.io/
   - https://quay.io/repository/minio/minio

--- a/recipes/minio/recipe.yaml
+++ b/recipes/minio/recipe.yaml
@@ -89,6 +89,9 @@ kind: Service
 metadata:
   name: minio-console
   namespace: minio-app
+  labels:
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/name: minio
 spec:
   selector:
     app.kubernetes.io/instance: minio
@@ -104,6 +107,9 @@ kind: IngressRoute
 metadata:
   name: minio-console-websecure
   namespace: minio-app
+  labels:
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/name: minio
 spec:
   entryPoints:
   - websecure

--- a/recipes/photoprism/metadata.yaml
+++ b/recipes/photoprism/metadata.yaml
@@ -5,9 +5,9 @@ architecture:
   - amd64
   - arm64
 url: https://www.photoprism.app/
-recipeVersion: "1.0.1"
+recipeVersion: "1.1.0"
 appVersion: latest
 maintainers:
-  - volker.theile@openmediavault.org
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://dl.photoprism.app/docker/docker-compose.yml

--- a/recipes/photoprism/recipe.yaml
+++ b/recipes/photoprism/recipe.yaml
@@ -1,4 +1,4 @@
-# The app can be reached at https://<FQDN>:8443/photoprism
+# The app can be reached at https://photoprism.<FQDN>:8443
 ---
 apiVersion: v1
 kind: Namespace
@@ -42,7 +42,9 @@ spec:
             - name: PHOTOPRISM_HTTP_PORT
               value: "2342"
             - name: PHOTOPRISM_SITE_URL
-              value: "http://localhost:2342/photoprism"
+              value: "https://photoprism.{{ fqdn() }}:8443"
+            - name: PHOTOPRISM_DISABLE_TLS
+              value: "true"
           envFrom:
             - secretRef:
                 name: photoprism
@@ -150,6 +152,9 @@ kind: Secret
 metadata:
   name: photoprism
   namespace: photoprism-app
+  labels:
+    app.kubernetes.io/instance: photoprism
+    app.kubernetes.io/name: photoprism
 stringData:
   PHOTOPRISM_ADMIN_PASSWORD: "admin"
   PHOTOPRISM_DATABASE_PASSWORD: "photoprism"
@@ -159,6 +164,9 @@ kind: Secret
 metadata:
   name: mariadb
   namespace: photoprism-app
+  labels:
+    app.kubernetes.io/instance: photoprism
+    app.kubernetes.io/name: photoprism
 stringData:
   MARIADB_PASSWORD: "photoprism"
   MARIADB_ROOT_PASSWORD: "photoprism"
@@ -178,6 +186,9 @@ kind: ConfigMap
 metadata:
   name: photoprism-db
   namespace: photoprism-app
+  labels:
+    app.kubernetes.io/instance: photoprism
+    app.kubernetes.io/name: photoprism
 data:
   PHOTOPRISM_DATABASE_DRIVER: "mysql"
   PHOTOPRISM_DATABASE_SERVER: "mariadb:3306"
@@ -189,6 +200,9 @@ kind: ConfigMap
 metadata:
   name: mariadb
   namespace: photoprism-app
+  labels:
+    app.kubernetes.io/instance: photoprism
+    app.kubernetes.io/name: photoprism
 data:
   MARIADB_AUTO_UPGRADE: "1"
   MARIADB_INITDB_SKIP_TZINFO: "1"
@@ -236,11 +250,14 @@ kind: IngressRoute
 metadata:
   name: photoprism-websecure
   namespace: photoprism-app
+  labels:
+    app.kubernetes.io/instance: photoprism
+    app.kubernetes.io/name: photoprism
 spec:
   entryPoints:
     - websecure
   routes:
-    - match: PathPrefix(`/photoprism`)
+    - match: Host(`photoprism.{{ fqdn() }}`)
       kind: Rule
       services:
         - name: photoprism

--- a/recipes/plex-media-server/metadata.yaml
+++ b/recipes/plex-media-server/metadata.yaml
@@ -4,10 +4,10 @@ section: video
 architecture:
   - amd64
 url: https://www.plex.tv/
-recipeVersion: "1.0.1"
+recipeVersion: "1.1.0"
 appVersion: latest
 maintainers:
-  - volker.theile@openmediavault.org
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://www.plex.tv/
   - https://github.com/plexinc/pms-docker/

--- a/recipes/plex-media-server/recipe.yaml
+++ b/recipes/plex-media-server/recipe.yaml
@@ -1,10 +1,4 @@
----
-# Plex Media Server does not support running behind a reverse proxy with
-# subpath, e.g. https://omv7box.local:8443/plex.
-# You can only access it via NodePort, e.g. http://omv7box.local:32400/web
-#
-# Uncomment the `IngressRoute` if you want to access Plex Media Server
-# via https://omv7box.local:8443 for example.
+# The app can be reached at https://plex.<FQDN>:8443
 ---
 apiVersion: v1
 kind: Namespace
@@ -16,6 +10,9 @@ kind: PersistentVolume
 metadata:
   name: config-dir
   namespace: plex-app
+  labels:
+    app.kubernetes.io/instance: plex-media-server
+    app.kubernetes.io/name: plex-media-server
 spec:
   storageClassName: shared-folder
   capacity:
@@ -34,6 +31,9 @@ kind: "PersistentVolumeClaim"
 metadata:
   name: config-dir
   namespace: plex-app
+  labels:
+    app.kubernetes.io/instance: plex-media-server
+    app.kubernetes.io/name: plex-media-server
 spec:
   storageClassName: shared-folder
   accessModes:
@@ -48,6 +48,9 @@ kind: HelmChart
 metadata:
   name: plex-media-server
   namespace: plex-app
+  labels:
+    app.kubernetes.io/instance: plex-media-server
+    app.kubernetes.io/name: plex-media-server
 spec:
   repo: https://raw.githubusercontent.com/plexinc/pms-docker/gh-pages
   chart: plex-media-server
@@ -60,7 +63,7 @@ spec:
     rclone:
       enabled: false
     service:
-      type: NodePort
+      type: ClusterIP
     extraEnv:
       # Specifies the UID for the process running in the container.
       PLEX_UID: "{{ uid('<NAME>') }}" # <<< Replace
@@ -68,19 +71,22 @@ spec:
       # Defaults to `users`.
       PLEX_GID: "{{ gid('users') }}" # <<< Replace if needed
 ---
-# apiVersion: traefik.containo.us/v1alpha1
-# kind: IngressRoute
-# metadata:
-#   name: plex-media-server-websecure
-#   namespace: plex-app
-# spec:
-#   entryPoints:
-#     - websecure
-#   routes:
-#     - match: PathPrefix(`/`)
-#       kind: Rule
-#       services:
-#         - name: plex-media-server
-#           port: 32400
-#   tls:
-#     secretName: host-selfsigned-cert # <<< Use 'host-imported-cert' if you want to use the SSL cert specified in the settings.
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: plex-media-server-websecure
+  namespace: plex-app
+  labels:
+    app.kubernetes.io/instance: plex-media-server
+    app.kubernetes.io/name: plex-media-server
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`plex.{{ fqdn() }}`)
+      kind: Rule
+      services:
+        - name: plex-media-server
+          port: 32400
+  tls:
+    secretName: host-selfsigned-cert # <<< Use 'host-imported-cert' if you want to use the SSL cert specified in the settings.

--- a/recipes/wetty/metadata.yaml
+++ b/recipes/wetty/metadata.yaml
@@ -7,10 +7,10 @@ architecture:
   - armhf
   - arm64
 url: https://butlerx.github.io/wetty/
-recipeVersion: "1.0.2"
+recipeVersion: "1.1.0"
 appVersion: latest
 maintainers:
-  - volker.theile@openmediavault.org
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://butlerx.github.io/wetty/
   - https://hub.docker.com/r/wettyoss/wetty/

--- a/recipes/wetty/recipe.yaml
+++ b/recipes/wetty/recipe.yaml
@@ -1,4 +1,4 @@
-# The app can be reached at https://<FQDN>:8443/wetty
+# The app can be reached at https://wetty.<FQDN>:8443
 ---
 apiVersion: v1
 kind: Namespace
@@ -37,7 +37,7 @@ spec:
             runAsGroup: {{ gid('nogroup') }}
           args:
             - "--port=3000"
-            - "--base=/wetty"
+            - "--base=/"
             - "--force-ssh"
             - "--ssh-port={{ conf_get('conf.service.ssh') | get('port') }}"
             - "--ssh-host={{ hostname() }}"
@@ -54,8 +54,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: wetty
-      port: 3000
+    - port: 3000
       protocol: TCP
       targetPort: 3000
   selector:
@@ -67,11 +66,14 @@ kind: IngressRoute
 metadata:
   name: wetty-websecure
   namespace: wetty-app
+  labels:
+    app.kubernetes.io/instance: wetty
+    app.kubernetes.io/name: wetty
 spec:
   entryPoints:
     - websecure
   routes:
-    - match: PathPrefix(`/wetty`)
+    - match: Host(`wetty.{{ fqdn() }}`)
       kind: Rule
       services:
         - name: wetty

--- a/recipes/whoami/metadata.yaml
+++ b/recipes/whoami/metadata.yaml
@@ -4,10 +4,11 @@ section: net
 architecture:
   - amd64
 url: https://hub.docker.com/r/traefik/whoami/
-recipeVersion: "1.0.0"
+recipeVersion: "1.1.0"
 appVersion: latest
 maintainers:
   - Richard Cottrill <richard_c@tpg.com.au>
+  - Volker Theile <volker.theile@openmediavault.org>
 sources:
   - https://github.com/traefik/whoami
   - https://doc.traefik.io/traefik/middlewares/overview/

--- a/recipes/whoami/recipe.yaml
+++ b/recipes/whoami/recipe.yaml
@@ -1,4 +1,4 @@
-# https://<FQDN>:8443/whoami
+# The app can be reached at https://whoami.<FQDN>:8443
 ---
 apiVersion: v1
 kind: Namespace
@@ -10,38 +10,37 @@ kind: Service
 metadata:
   name: whoami
   namespace: whoami-app
+  labels:
+    app.kubernetes.io/instance: whoami
+    app.kubernetes.io/name: whoami
 spec:
   ports:
-  - name: whoami
-    port: 80
-    targetPort: web
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
   selector:
-    app: whoami
----
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: test-stripprefix
-  namespace: whoami-app
-spec:
-  stripPrefix:
-    prefixes:
-      - /whoami
+    app.kubernetes.io/instance: whoami
+    app.kubernetes.io/name: whoami
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: whoami-app
   name: whoami
+  labels:
+    app.kubernetes.io/instance: whoami
+    app.kubernetes.io/name: whoami
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: whoami
+      app.kubernetes.io/instance: whoami
+      app.kubernetes.io/name: whoami
   template:
     metadata:
       labels:
-        app: whoami
+        app.kubernetes.io/instance: whoami
+        app.kubernetes.io/name: whoami
     spec:
       containers:
         - name: whoami
@@ -72,25 +71,26 @@ spec:
           resources:
             limits:
               memory: '50Mi'
-              cpu: '500m'
+              cpu: '500m' # 50%
           ports:
-            - name: web
-              containerPort: 8080
+            - containerPort: 8080
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: whoami
+  name: whoami-websecure
   namespace: whoami-app
+  labels:
+    app.kubernetes.io/instance: whoami
+    app.kubernetes.io/name: whoami
 spec:
   entryPoints:
     - websecure
   routes:
-    - match: PathPrefix(`/whoami`)
+    - match: Host(`whoami.{{ fqdn() }}`)
       kind: Rule
-      middlewares:
-        - name: test-stripprefix
-          namespace: whoami-app
       services:
         - name: whoami
           port: 80
+  tls:
+    secretName: host-selfsigned-cert # <<< Use 'host-imported-cert' if you want to use the SSL cert specified in the settings.


### PR DESCRIPTION
... because many software can not handle that correctly.

Example:
`https://<FQDN>:8443/filebrowser` => `https://filebrowser.<FQDN>:8443`

Signed-off-by: Volker Theile <votdev@gmx.de>