### PR TITLE
Add recipe for LetsEncrypt and acme-dns

### DIFF
--- a/recipes/acme-dns/README.md
+++ b/recipes/acme-dns/README.md
@@ -1,0 +1,34 @@
+The acme-dns HTTPS API is reverse-proxied through `https://acme-dns.<FQDN>:8443` .
+
+Note: Unlike default acme-dns setup, the API is **not accessible** at `https://auth.<your-domain>/` !
+
+----
+
+To start, port forward UDP & TCP [your-public-ip]:53 to [k8s-machine]:30053.
+(DNS standards mandate the use of Port 53 but Kubernetes does not allow :53 as
+a NodePort by default.)
+
+Then create the following records at your DNS provider:
+
+```
+auth.your-domain.test. NS auth-ns.your-domain.test.
+auth-ns.your-domain.test. A 0.0.0.0 # Replace 0.0.0.0 with your public IP.
+```
+
+If you're using a dynamic DNS service where `mybox.ddns-provider.test` points
+to your public address, you just need one `NS` record to point at it.
+
+Don't forget to update the `nsname` variable in the recipe to match.
+
+```
+auth.your-domain.test. NS mybox.ddns-provider.test.
+```
+
+You can then follow the official testing instructions (just remember to use the
+base URL mentioned above instead of `auth.example.org`):
+
+https://github.com/joohoi/acme-dns?tab=readme-ov-file#testing-it-out
+
+You may have to ignore certificate warnings if `<FQDN>` is not a public domain
+or if the default certificate is selfsigned, e.g.
+`curl --insecure -X POST https://acme-dns.<FQDN>:8443/register`

--- a/recipes/acme-dns/metadata.yaml
+++ b/recipes/acme-dns/metadata.yaml
@@ -1,0 +1,12 @@
+name: acme-dns
+description: Run a simplified DNS server to automate ACME DNS challenges.
+section: net
+architecture:
+  - amd64
+url: https://github.com/joohoi/acme-dns
+recipeVersion: "1.2.2"
+appVersion: latest
+maintainers:
+  - Yuchen Shi <yuchenshi@google.com>
+sources:
+  - https://github.com/joohoi/acme-dns

--- a/recipes/acme-dns/recipe.yaml
+++ b/recipes/acme-dns/recipe.yaml
@@ -1,0 +1,180 @@
+# The acme-dns API can be reached at https://acme-dns.<FQDN>:8443
+# Change the following variables to adapt the recipe to your needs.
+# Change this to the domain (zone) that ACME DNS should manage.
+{% set domain = 'auth.' ~ fqdn() %}
+# At your DNS provider, create the following record:
+#     {{ domain }}. NS {{ nsname }}.
+# Example:
+#     auth.example.org. NS auth-ns.example.org.
+# Change this to a domain that has an A/AAAA record with your public IP.
+# It may be a DDNS domain or dynamically updated as the IP changes.
+# It must not be the same or a subdomain of the above.
+{% set nsname = 'auth-ns.' ~ fqdn() %}
+# See README.md for required port forwarding and DNS records setup.
+# !!! Only modify the following manifest if you need to make custom changes. !!!
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acme-dns-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: acme-dns
+  namespace: acme-dns-app
+  labels:
+    app.kubernetes.io/instance: acme-dns
+    app.kubernetes.io/name: acme-dns
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/instance: acme-dns
+    app.kubernetes.io/name: acme-dns
+  ports:
+  - name: dns-tcp
+    port: 53
+    nodePort: 30053
+    protocol: TCP
+  - name: dns-udp
+    port: 53
+    nodePort: 30053
+    protocol: UDP
+  - name: http
+    port: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acme-dns-config
+  namespace: acme-dns-app
+  labels:
+    app.kubernetes.io/instance: acme-dns
+    app.kubernetes.io/name: acme-dns
+data:
+  config.cfg: |
+    [general]
+    listen = ":53"
+    protocol = "both"
+    # domain name to serve the requests off of
+    domain = "{{ domain }}"
+    # zone name server
+    nsname = "{{ nsname }}"
+    # admin email address, where @ is substituted with .
+    nsadmin = "ns-admin.{{ nsname }}"
+    # predefined records served in addition to the TXT
+    records = [
+        # specify that {{ nsname }} will resolve any *.{{ domain }} records
+        "{{ domain }}. NS {{ nsname }}.",
+        # Note: We intentionally don't add an A record for either domain to
+        # avoid hard-coding IP addresses that may change on a home network.
+        # To access the API server, use acme-dns.{{ fqdn() }} instead (route below).
+    ]
+    # debug messages from CORS etc
+    debug = false
+
+    [database]
+    # Database engine to use, sqlite3 or postgres
+    engine = "sqlite3"
+    # Connection string, filename for sqlite3 and postgres://$username:$password@$host/$db_name for postgres
+    connection = "/var/lib/acme-dns/acme-dns.db"
+    # connection = "postgres://user:password@localhost/acmedns_db"
+
+    [api]
+    ip = "0.0.0.0"
+    # disable registration endpoint
+    disable_registration = false
+    port = "80"
+    tls = "none"
+    # CORS AllowOrigins, wildcards can be used
+    corsorigins = [
+        "*"
+    ]
+    # use HTTP header to get the client ip
+    use_header = false
+    # header name to pull the ip address / list of ip addresses from
+    header_name = "X-Forwarded-For"
+
+    [logconfig]
+    # logging level: "error", "warning", "info" or "debug"
+    loglevel = "debug"
+    logtype = "stdout"
+    # format, either "json" or "text"
+    logformat = "text"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: acme-dns-app
+  name: acme-dns
+  labels:
+    app.kubernetes.io/instance: acme-dns
+    app.kubernetes.io/name: acme-dns
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: acme-dns
+      app.kubernetes.io/name: acme-dns
+  serviceName: acme-dns-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: acme-dns
+        app.kubernetes.io/name: acme-dns
+    spec:
+      containers:
+      - name: acme-dns
+        image: joohoi/acme-dns:latest
+        imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: '50Mi'
+            cpu: '500m' # 50%
+        volumeMounts:
+        - name: acme-dns-data
+          mountPath: /var/lib/acme-dns
+        - name: acme-dns-config
+          mountPath: /etc/acme-dns
+      volumes:
+        - name: acme-dns-config
+          configMap:
+            name: acme-dns-config
+  volumeClaimTemplates:
+  - metadata:
+      name: acme-dns-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 200Mi
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: acme-dns-websecure
+  namespace: acme-dns-app
+  labels:
+    app.kubernetes.io/instance: acme-dns
+    app.kubernetes.io/name: acme-dns
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`acme-dns.{{ fqdn() }}`)
+      kind: Rule
+      services:
+        - name: acme-dns
+          port: 80
+  tls: {}

--- a/recipes/letsencrypt/metadata.yaml
+++ b/recipes/letsencrypt/metadata.yaml
@@ -1,0 +1,12 @@
+name: letsencrypt
+description: Acquire a TLS certificate from LetsEncrypt (or other ACME-compatible CAs).
+section: net
+architecture:
+  - amd64
+url: https://cert-manager.io/docs/configuration/acme/
+recipeVersion: "1.2.2"
+appVersion: latest
+maintainers:
+  - Yuchen Shi <yuchenshi@google.com>
+sources:
+  - https://cert-manager.io/docs/configuration/acme/

--- a/recipes/letsencrypt/recipe.yaml
+++ b/recipes/letsencrypt/recipe.yaml
@@ -1,0 +1,130 @@
+# This recipe acquires TLS certs for your domain. There's no web page / API.
+# Change the following variables and solvers to adapt the recipe to your needs.
+#
+# This must be a public domain name that you own (resolvable via global DNS).
+# If fqdn() is private / internal, use a different domain like this:
+# {% set domain = 'optional-nested-domain.my-domain.tld' %}
+{% set domain = fqdn() %}
+# It is highly recommended to try staging first to avoid rate limiting.
+# Once it works, flip this to false to get a new cert trusted by the browsers.
+{% set staging = true %}
+#
+# To use the certificate(s), recipes must be modified in the following ways:
+# 1. Each routes[*].match statement in IngressRoute must reference the same
+#    domain name as specified above. (The certificate will not be used if there
+#    is no `Host` in match or the domain is not covered by the certificate. By
+#    default a wildcard cert is requested, but note that it only covers one
+#    level below like `sub.{{ domain }}`, not `nested.sub.{{ domain }}`.)
+# 2. The tls section of each IngressRoute must explicitly reference the secret.
+#    (This recipe will take care of copying the TLS secret to all namespaces.)
+#
+# Example (only showing relevant parts):
+# ---
+# kind: IngressRoute
+# spec:
+#   routes:
+#   # 1. If you picked a different domain than fqdn() then remember to change
+#   # all match statements that contain `someapp.{{ fqdn() }}`. Make sure:
+#   # This string  vvvvvvvvvvvvvvv must be {{ domain }} or a direct subdomain.
+#   - match: Host(`sub.example.com`)
+#     kind: Rule
+#     ...
+#   # 2. Change every occurrence of `tls: {}` to these two lines instead.
+#   tls:
+#     secretName: letsencrypt-cert
+#   # ... (other fields can be left untouched.)
+# ...
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: letsencrypt-app
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt{{ staging ? '-staging' }}
+  namespace: letsencrypt-app
+  labels:
+    app.kubernetes.io/instance: letsencrypt{{ staging ? '-staging' }}
+    app.kubernetes.io/name: letsencrypt
+spec:
+  acme:
+    server: https://acme{{ staging ? '-staging' }}-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt{{ staging ? '-staging' }}
+    solvers:
+      # dns01 must be used instead of http if you want wildcard certs.
+      - dns01:
+          # TODO: Configure your own solver, such as acmeDNS, webhook, etc.
+          # https://cert-manager.io/docs/configuration/acme/
+          # The sample config below works with the acme-dns recipe.
+          acmeDNS:
+            host: http://acme-dns.acme-dns-app
+            accountSecretRef:
+              name: acme-dns
+              key: acmedns.json
+---
+# This sample secret works with the acme-dns recipe -- just fill in the JSON.
+# If you use another solver, you may need a different secret structure, e.g.
+# username + password / API key from your DNS provider. See:
+# https://cert-manager.io/docs/configuration/acme/
+apiVersion: v1
+kind: Secret
+metadata:
+  name: acme-dns
+  namespace: cert-manager # This has to be in the "cluster resource namespace".
+type: Opaque
+stringData:
+  acmedns.json: |
+    {
+      "{{ domain }}": {
+        "username":"<your-registered-username-from-acmedns>",
+        "password":"<your-registered-password-from-acmedns>",
+        "fulldomain":"<your-registered-fulldomain-from-acmedns>",
+        "subdomain":"<your-registered-subdomain-from-acmedns>",
+        "allowfrom":[]
+      }
+    }
+# !!! Only modify the following manifest if you need to make custom changes. !!!
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: letsencrypt-cert
+  namespace: letsencrypt-app
+spec:
+  commonName: '{{ domain }}'
+  dnsNames:
+    # Recommended setting: a single cert for base domain + wildcard subdomains.
+    # If dns01 challenge is not viable, remove the wildcard entry and add one
+    # Certificate covering each subdomain.{{ domain }}.
+    # WARNING: Beware of the (rather tight) rate limits! You may not hit it on
+    # staging, but you'll very likely hit it on prod with one-cert-for-each.
+    # https://letsencrypt.org/docs/rate-limits/
+    - '{{ domain }}'
+    - '*.{{ domain }}'
+  issuerRef:
+    name: letsencrypt{{ staging ? '-staging' }}
+    kind: ClusterIssuer
+  secretName: letsencrypt-cert
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "^(?!(?:cert-manager|kube-system|kube-node-lease|kube-public)$).*"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "" # all namespaces, filtered by allowed namespaces
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: reflector
+  namespace: letsencrypt-app
+  labels:
+    app.kubernetes.io/instance: reflector
+    app.kubernetes.io/name: reflector
+spec:
+  repo: https://emberstack.github.io/helm-charts
+  chart: reflector
+  version: 9.1.7
+  targetNamespace: letsencrypt-app


### PR DESCRIPTION
Idea from https://github.com/openmediavault/openmediavault/issues/1957#issuecomment-2864816500

Tested on a fresh new k3s setup on OMV7. The letsencrypt recipe works almost out of the box with the acme-dns recipe besides registration.

I'm not exactly sure what should go into `README.md` files so suggestions are welcome. (As far as I can tell, README.md is not displayed when applying a recipe using the OMV dashboard -- should all instructions for end users go into `recipe.yaml`s as comments?)