### PR TITLE
Add Filebrowser Quantum Recipe

### DIFF
--- a/recipes/filebrowser-quantum/metadata.yaml
+++ b/recipes/filebrowser-quantum/metadata.yaml
@@ -7,7 +7,7 @@ architecture:
   - armhf
   - arm64
 url: https://github.com/gtsteffaniak/filebrowser
-recipeVersion: "1.2.3"
+recipeVersion: "1.0.0"
 appVersion: "latest"
 maintainers:
   - Volker Theile <volker.theile@openmediavault.org>

--- a/recipes/filebrowser-quantum/metadata.yaml
+++ b/recipes/filebrowser-quantum/metadata.yaml
@@ -1,0 +1,16 @@
+name: FileBrowser Quantum
+description: Web file browser.
+section: net
+architecture:
+  - amd64
+  - armel
+  - armhf
+  - arm64
+url: https://github.com/gtsteffaniak/filebrowser
+recipeVersion: "1.2.3"
+appVersion: "latest"
+maintainers:
+  - Volker Theile <volker.theile@openmediavault.org>
+sources:
+  - https://github.com/gtsteffaniak/filebrowser
+  - https://github.com/gtsteffaniak/filebrowser/pkgs/container/filebrowser

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -47,18 +47,15 @@ spec:
           # Specifies the GID for the process running in the container.
           # Defaults to `users`.
           runAsGroup: {{ gid(runAsGroup) }}
-        env:
-        - name: "FILEBROWSER_CONFIG"
-          value: "/data/config.yaml"
         ports:
         - containerPort: 80
           name: web-ui
           protocol: TCP
         volumeMounts:
         - name: data
-          mountPath: "/data/"
-        - name: shared
-          mountPath: "/shared/"
+          mountPath: "/home/filebrowser"
+        - name: srv
+          mountPath: "/srv"
       restartPolicy: Always
       volumes:
       - name: data
@@ -68,7 +65,7 @@ spec:
           # Make sure the configured UID/GID the container is running
           # with has access to that directory.
           path: {{ sharedfolder_path(dataSharedFolderName) }}
-      - name: shared
+      - name: srv
         hostPath:
           type: Directory
           # Insert the name of the shared folder you want to use.
@@ -122,3 +119,4 @@ spec:
       services:
         - name: filebrowser-quantum
           port: 80
+  tls: {}

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -48,13 +48,11 @@ spec:
           # Defaults to `users`.
           runAsGroup: {{ gid(runAsGroup) }}
         env:
-        - name: "FILEBROWSER_ADMIN_PASSWORD"
-          value: {{ adminPassword }}
         - name: "FILEBROWSER_CONFIG"
           value: "/data/config.yaml"
         ports:
         - containerPort: 80
-          name: ui
+          name: web-ui
           protocol: TCP
         volumeMounts:
         - name: data
@@ -78,6 +76,35 @@ spec:
           # with has access to that directory.
           path: {{ sharedfolder_path(rootSharedFolderName) }}
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: filebrowser-quantum
+  namespace: filebrowser-quantum-app
+  labels:
+    app.kubernetes.io/instance: filebrowser-quantum
+    app.kubernetes.io/name: filebrowser-quantum
+stringData:
+  FILEBROWSER_ADMIN_PASSWORD: {{ adminPassword }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: filebrowser-quantum
+  namespace: filebrowser-quantum-app
+  labels:
+    app.kubernetes.io/instance: filebrowser-quantum
+    app.kubernetes.io/name: filebrowser-quantum
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      name: web-ui
+      port: 80
+  selector:
+    app.kubernetes.io/instance: filebrowser-quantum
+    app.kubernetes.io/name: filebrowser-quantum
+---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -95,4 +122,3 @@ spec:
       services:
         - name: filebrowser-quantum
           port: 80
-  tls: {}

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -4,6 +4,8 @@
 {% set runAsGroup = 'users' %}
 # Set the admin password for the web-ui
 {% set adminPassword = '<MODIFY>' %}
+{% set configFilename = 'default_config.yaml' %}
+{% set baseURL = '/' %}
 # Insert the name of the shared folder you want to use. Make sure the
 # configured UID/GID the container is running with has access to that
 # directory.
@@ -15,6 +17,37 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: filebrowser-quantum-app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebrowser-quantum-config
+  namespace: filebrowser-quantum-app
+data:
+  default_config.yaml: |
+    server:
+      port: 80
+      baseURL:  {{ baseURL }}
+      logging:
+        - levels: "info|warning|error"
+      cacheDir: /data/tmp
+      sources:
+        - path: "/srv"
+    userDefaults:
+      preview:
+        image: true
+        popup: true
+        video: false
+        office: false
+        highQuality: false
+      darkMode: true
+      disableSettings: false
+      singleClick: false
+      permissions:
+        admin: false
+        modify: false
+        share: false
+        api: false
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -53,12 +86,19 @@ spec:
           protocol: TCP
         env:
         - name: FILEBROWSER_CONFIG
-          value: /data/config.yaml
+          value: /data/{{ configFilename }}
         - name: FILEBROWSER_DATABASE
           value: /data/database.db
+        envFrom:
+        - secretRef:
+            name: filebrowser-quantum
         volumeMounts:
         - name: data
           mountPath: "/data"
+        - name: default-config
+          mountPath: "/data/default_config.yaml"
+          readOnly: true
+          subPath: default_config.yaml
         - name: srv
           mountPath: "/srv"
       restartPolicy: Always
@@ -70,6 +110,9 @@ spec:
           # Make sure the configured UID/GID the container is running
           # with has access to that directory.
           path: {{ sharedfolder_path(dataSharedFolderName) }}
+      - name: default-config
+        configMap:
+          name: filebrowser-quantum-config
       - name: srv
         hostPath:
           type: Directory

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -53,7 +53,7 @@ spec:
           protocol: TCP
         volumeMounts:
         - name: data
-          mountPath: "/home/filebrowser"
+          mountPath: "/home/filebrowser/data"
         - name: srv
           mountPath: "/srv"
       restartPolicy: Always

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -51,7 +51,7 @@ spec:
         - containerPort: 80
           name: web-ui
           protocol: TCP
-      - env:
+        env:
         - name: FILEBROWSER_CONFIG
           value: /data/config.yaml
         volumeMounts:

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -1,0 +1,98 @@
+# The app can be reached at https://filebrowser.<FQDN>:8443
+# Change the following variables to adapt the recipe to your needs.
+{% set runAsUser = 'nobody' %}
+{% set runAsGroup = 'users' %}
+# Set the admin password for the web-ui
+{% set adminPassword = '<MODIFY>' %}
+# Insert the name of the shared folder you want to use. Make sure the
+# configured UID/GID the container is running with has access to that
+# directory.
+{% set dataSharedFolderName = '<MODIFY>' %}
+{% set rootSharedFolderName = '<MODIFY>' %}
+# !!! Only modify the following manifest if you need to make custom changes. !!!
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: filebrowser-quantum-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: filebrowser-quantum
+    app.kubernetes.io/name: filebrowser-quantum
+  name: filebrowser-quantum
+  namespace: filebrowser-quantum-app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: filebrowser-quantum
+      app.kubernetes.io/name: filebrowser-quantum
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: filebrowser-quantum
+        app.kubernetes.io/name: filebrowser-quantum
+    spec:
+      containers:
+      - name: filebrowser-quantum
+        image: ghcr.io/gtsteffaniak/filebrowser
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsNonRoot: true
+          # Specifies the UID for the process running in the container.
+          runAsUser: {{ uid(runAsUser) }}
+          # Specifies the GID for the process running in the container.
+          # Defaults to `users`.
+          runAsGroup: {{ gid(runAsGroup) }}
+        env:
+        - name: "FILEBROWSER_ADMIN_PASSWORD"
+          value: {{ adminPassword }}
+        - name: "FILEBROWSER_CONFIG"
+          value: "/data/config.yaml"
+        ports:
+        - containerPort: 80
+          name: ui
+          protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: "/data/"
+        - name: shared
+          mountPath: "/shared/"
+      restartPolicy: Always
+      volumes:
+      - name: data
+        hostPath:
+          type: Directory
+          # Insert the name of the shared folder you want to use.
+          # Make sure the configured UID/GID the container is running
+          # with has access to that directory.
+          path: {{ sharedfolder_path(dataSharedFolderName) }}
+      - name: shared
+        hostPath:
+          type: Directory
+          # Insert the name of the shared folder you want to use.
+          # Make sure the configured UID/GID the container is running
+          # with has access to that directory.
+          path: {{ sharedfolder_path(rootSharedFolderName) }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: filebrowser-quantum-websecure
+  namespace: filebrowser-quantum-app
+  labels:
+    app.kubernetes.io/instance: filebrowser-quantum
+    app.kubernetes.io/name: filebrowser-quantum
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`filebrowser.{{ fqdn() }}`)
+      kind: Rule
+      services:
+        - name: filebrowser-quantum
+          port: 80
+  tls: {}

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -2,10 +2,7 @@
 # Change the following variables to adapt the recipe to your needs.
 {% set runAsUser = 'nobody' %}
 {% set runAsGroup = 'users' %}
-# Set the admin password for the web-ui
-{% set adminPassword = '<MODIFY>' %}
-{% set configFilename = 'default_config.yaml' %}
-{% set baseURL = '/' %}
+{% set adminPassword = 'admin' %}
 # Insert the name of the shared folder you want to use. Make sure the
 # configured UID/GID the container is running with has access to that
 # directory.
@@ -27,7 +24,7 @@ data:
   default_config.yaml: |
     server:
       port: 80
-      baseURL:  {{ baseURL }}
+      baseURL: "/"
       logging:
         - levels: "info|warning|error"
       cacheDir: /data/tmp
@@ -82,11 +79,10 @@ spec:
           runAsGroup: {{ gid(runAsGroup) }}
         ports:
         - containerPort: 80
-          name: web-ui
           protocol: TCP
         env:
         - name: FILEBROWSER_CONFIG
-          value: /data/{{ configFilename }}
+          value: /data/default_config.yaml
         - name: FILEBROWSER_DATABASE
           value: /data/database.db
         envFrom:
@@ -144,7 +140,6 @@ spec:
   type: ClusterIP
   ports:
     - protocol: TCP
-      name: web-ui
       port: 80
   selector:
     app.kubernetes.io/instance: filebrowser-quantum

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -51,9 +51,12 @@ spec:
         - containerPort: 80
           name: web-ui
           protocol: TCP
+      - env:
+        - name: FILEBROWSER_CONFIG
+          value: /data/config.yaml
         volumeMounts:
         - name: data
-          mountPath: "/home/filebrowser/data"
+          mountPath: "/data"
         - name: srv
           mountPath: "/srv"
       restartPolicy: Always

--- a/recipes/filebrowser-quantum/recipe.yaml
+++ b/recipes/filebrowser-quantum/recipe.yaml
@@ -54,6 +54,8 @@ spec:
         env:
         - name: FILEBROWSER_CONFIG
           value: /data/config.yaml
+        - name: FILEBROWSER_DATABASE
+          value: /data/database.db
         volumeMounts:
         - name: data
           mountPath: "/data"


### PR DESCRIPTION
This is a recipe for a fork of Filebrowser called Filebrowser Quantum (https://github.com/gtsteffaniak/filebrowser).

It is currently in beta, however, some benefits of Filebrowser Quantum include the ability to serve multiple folders and OIDC authentication.

This deployment configures two folders.
 - `dataSharedFolderName`, mounted in the container at `/data`, which stores the `config.yaml` and optionally the database
 - `rootSharedFolderName`, mounted in the container at `/srv`, which serves the files that should be accessible via the Filebrowser UI. Users can manually configure additional folders to serve.

The deployment requires the creation of a [`config.yaml`](https://github.com/gtsteffaniak/filebrowser/wiki/Full-Config-Example) file in the `dataSharedFolderName` folder. In that file, the database path can be changed so it will be persisted. I tried making `dataSharedFolderName` mount to the default database and config path, `/home/filebrowser/data/{database.db,config.yaml}`, but I was encountering permission issues that I did not know how to address -- I am not all too familiar with kubernetes.
 
