### PR TITLE
Fix typo in shared folder name for mariadb in the photoprism recipe

### DIFF
--- a/recipes/photoprism/recipe.yaml
+++ b/recipes/photoprism/recipe.yaml
@@ -158,7 +158,7 @@ spec:
             # Insert the name of the shared folder you want to use.
             # Make sure the configured UID/GID the container is running
             # with has access to that directory.
-            path: {{ sharedfolder_path(mariadbSharedFolderName) }}
+            path: {{ sharedfolder_path(mariaDbSharedFolderName) }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
The `photoprism` recipe defines the variable `mariaDbSharedFolderName` at
https://github.com/openmediavault/openmediavault-k8s-recipes/blob/df2e8e2ac1ac4eb283eec726d99c72194ea51f68/recipes/photoprism/recipe.yaml#L15
but refers to `mariadbSharedFolderName` at
https://github.com/openmediavault/openmediavault-k8s-recipes/blob/010609c001003504ffd29d5a678024ce542fcf0b/recipes/photoprism/recipe.yaml#L161.