### PR TITLE
Fix password escaping on paperless-ngx recipe

### DIFF
--- a/recipes/paperless-ngx/recipe.yaml
+++ b/recipes/paperless-ngx/recipe.yaml
@@ -79,8 +79,8 @@ spec:
     mariadb:
       enabled: true
       auth:
-        password: {{ dbPassword }}
-        rootPassword: {{ dbRootPassword }}
+        password: "{{ dbPassword }}"
+        rootPassword: "{{ dbRootPassword }}"
     persistence:
       data:
         enabled: true


### PR DESCRIPTION
- Tried to install the recipe with a randomly generated password which contained special characters
- Installation failed, and I tracked the issue to this:
The database password was not properly escaped in this recipe

The other passwords of this recipe are already properly escaped